### PR TITLE
Add the functionality to memorize "temporal variable" to use it after chain evaluation

### DIFF
--- a/R/magrittr.R
+++ b/R/magrittr.R
@@ -36,7 +36,7 @@ NULL
 #'        compound call when environments are locked.
 #'
 #' @return an environment.
-pipe_env <- function(parent, compound = NULL)
+pipe_env <- function(parent, compound = NULL, memorize = NULL)
 {
   # Create a new environment, and set top-level
   env <- new.env(parent = parent)
@@ -45,7 +45,7 @@ pipe_env <- function(parent, compound = NULL)
   env[["__locked__"]]   <- FALSE     # controls whether the env can be re-used.
   env[["__compound__"]] <- compound  # a call for compound assignemt. Can be
                                      #  set here, in cases of locked envirs.
-
+  env[["__memorize__"]] <- memorize  # region for variables you can use after chain evaluation
   env
 }
 
@@ -65,9 +65,9 @@ pipe_env <- function(parent, compound = NULL)
 #' @rdname magrittr-internal
 #'
 #' @details This is not exported.
-pipe <- function(tee = FALSE, compound = FALSE)
+pipe <- function(tee = FALSE, compound = FALSE, memorize = FALSE)
 {
-  if (tee && compound)
+  if (sum(tee, compound, memorize) >=2)
     stop("Invalid pipe specification.", call. = FALSE)
 
   function(lhs, rhs)
@@ -161,12 +161,16 @@ pipe <- function(tee = FALSE, compound = FALSE)
       #   * rhs has one or more dots that qualify as placeholder for lhs.
       #   * lhs is placed as first argument in rhs call.
       if (is.symbol(rhs)) {
-
-        if (!exists(deparse(rhs), env, mode = "function"))
+        if(memorize){
+          env[["__memorize__"]] <- append(env[["__memorize__"]], call("<-", rhs, lhs))
+          e <- env[[nm]]
+        }
+        else if (!exists(deparse(rhs), env, mode = "function")){
           stop("RHS appears to be a function name, but it cannot be found.")
-
-        e <- call(as.character(rhs), as.name(nm))
-
+        }
+        else {
+          e <- call(as.character(rhs), as.name(nm))
+        }
       } else {
 
         # Match `.` placeholder at outmost level.
@@ -201,6 +205,10 @@ pipe <- function(tee = FALSE, compound = FALSE)
     # clean the environment to keep it light in long chains.
     if (nm != ".")
       rm(list = nm, envir = env)
+
+    if (toplevel && !is.null(env[["__memorize__"]])) {
+      lapply(get("__memorize__", env), function(m) eval(m, parent, parent))
+    }
 
     if (toplevel && !is.null(env[["__compound__"]])) {
 
@@ -296,3 +304,21 @@ pipe <- function(tee = FALSE, compound = FALSE)
 #' colnames(some.data) %<>% paste0("!")
 #' some.data[, 1] %<>% multiply_by(2)
 `%<>%` <- pipe(compound = TRUE)
+
+#' Memorize pipe operator
+#'
+#' Use to overwrite/mask the left-hand side with the result of
+#' piping it forward into the right-hand side, which itself may be a chain.
+#'
+#' @param lhs a symbol or expression which may serve as left-hand
+#'        side for \code{`<-`}.
+#' @param rhs a function/call/expression/chain.
+#' @return No return value. Works by assigning the result.
+#' @rdname compound.op
+#' @export
+#' @examples
+#'
+#' x <- 1:10
+#' x %>% sum %->% y %>% multiply_by(10)
+#' y
+`%->%` <- pipe(memorize = TRUE)


### PR DESCRIPTION
Hi;
Thank you for your great package.
I'm really fascinated by your approach(and F#?).

I try to introduce the functionality to "memorize" temporal variable to use after the chain evaluation.
I think that it is very usefule when you chain data manipulation and visualization 
because processed data will be needed sometimes after chain evaluation.

For example, you can write like the following using "%->%" operator I made.

``` r
x <- 1:10
x %>% sum %->% y %>% multiply_by(10)
y
(output)
[1] 55
```

And as second example,

``` r
iris %>% group_by(Species) %>% summarise(mn=mean(Sepal.Length)) %->% res %>% qplot(data=.,x=Species,y=mn,geom="bar",stat="identity")
res
(output)
Source: local data frame [3 x 2]

     Species    mn
1     setosa 5.006
2 versicolor 5.936
3  virginica 6.588
```

Let me know what you think.
