### PR TITLE
Accept funs preceded by "::", ":::" without parens

### DIFF
--- a/R/is_something.R
+++ b/R/is_something.R
@@ -56,6 +56,16 @@ is_funexpr <- function(expr)
   is.call(expr) && identical(expr[[1]], quote(`{`))
 }	
 
+# Check whether expression has double or triple colons
+#
+# @param  expr An expression to be tested.
+# @return logical - TRUE if expr contains `::` or `:::`, FALSE otherwise.
+is_colexpr <- function(expr)
+{
+  is.call(expr) &&
+    (identical(expr[[1L]], quote(`::`)) || identical(expr[[1L]], quote(`:::`)))
+}
+
 # Check whether a symbol is the magrittr placeholder.
 #
 # @param  symbol A (quoted) symbol

--- a/R/split_chain.R
+++ b/R/split_chain.R
@@ -25,7 +25,7 @@ split_chain <- function(expr, env)
     rhss[[i]] <- 
       if (is_dollar(pipes[[i]]) || is_funexpr(rhs))
         rhs
-      else if (is_function(rhs))
+      else if (is_function(rhs) || is_colexpr(rhs))
         prepare_function(rhs)
       else if (is_first(rhs)) 
         prepare_first(rhs)


### PR DESCRIPTION
I had reported in #12 that magrittr doesn't accept functions preceded by `::` without parentheses (e.g. `2 %>% base::sqrt`, which is a silly, but simple example), but I also realized that the infix `:::` isn't supported either.

@smbache mentioned that `::` is really just a function and he's right, but I haven't yet seen a piece of code like ``::`(base, sqrt)`, and AFAIK that can't be translated to pipe-like syntax (`base %>% `::`(sqrt)` doesn't work since it doesn't recognize `base`). However I often find myself specifying namespaces to ensure that I'm calling the right function, e.g. `lme4::VarCorr` vs. `nlme::VarCorr`, `magrittr::extract` vs. `rstan::extract`, etc.

The solution proposed by @smbache, namely surrounding the expression with parens (e.g. `2 %>% (base::sqrt)`), works but I feel like it's unnecessarily verbose and in a way counterintuitive, i.e. if `2 %>% sqrt` works, I would expect `2 %>% base::sqrt` to work, just as I expect `sqrt(2)` and `base::sqrt(2)` to work as well.
