### PR TITLE
Install magrittr marker in pipe environment

### DIFF
--- a/R/construct_pipeline.R
+++ b/R/construct_pipeline.R
@@ -21,6 +21,13 @@ construct_pipeline <- function(expr, env)
   last  <- seq_along(rhss) == length(rhss)
   
   statements <- Map(finalize_rhs, rhss, pipes, last)
+
+  # Statement that adds a link to the caller environment within the
+  # pipe evaluation frame. The environment is inlined as a literal
+  # within the statement.
+  install_marker <- quote(`__magrittr_caller_env` <- env)
+  install_marker[[3]] <- env
+  statements <- c(install_marker, statements)
   
   body <- as.call(c(quote(`{`), statements))
   

--- a/R/construct_pipeline.R
+++ b/R/construct_pipeline.R
@@ -24,7 +24,7 @@ construct_pipeline <- function(expr, env)
   
   body <- as.call(c(quote(`{`), statements))
   
-  fun <- eval(call("function", as.pairlist(alist(.=)), body), env, env)
+  fun <- eval(call("function", as.pairlist(alist(.=)), body), env)
 
   compound <- is_compound_pipe(pipes[[1]])
   

--- a/R/pipe.R
+++ b/R/pipe.R
@@ -32,7 +32,7 @@ pipe <- function()
       
       cl <- call("<-", pipeline[["lhs"]], new_rhs)
       
-      eval(cl, parent, parent)
+      eval(cl, parent)
     
     } else if (dot) {
       
@@ -41,7 +41,7 @@ pipe <- function()
     } else {
       
       # These two lines make error scenarios print more nicely.
-      . <- eval(pipeline[["lhs"]], parent, parent)
+      . <- eval(pipeline[["lhs"]], parent)
       pipeline <- pipeline[["fun"]]
     
       # This temporary result variable is needed for backward compatibility

--- a/R/tokenize_pipeline.R
+++ b/R/tokenize_pipeline.R
@@ -11,7 +11,7 @@
 tokenize_pipeline <- function(expr, env)
 {
   if (is_parenthesized(expr))
-    expr <- eval(expr, env, env)
+    expr <- eval(expr, env)
   
   if (is_formularized(expr))
     expr <- expr[[2L]]

--- a/tests/testthat/test-caller-env.R
+++ b/tests/testthat/test-caller-env.R
@@ -1,0 +1,12 @@
+context("caller env")
+
+test_that("pipeline evaluation frame features a caller env marker", {
+  nms1 <- mtcars %>% { ls(environment()) }
+  nms2 <- mtcars %>% identity() %>% { ls(environment()) }
+  expect_true("__magrittr_caller_env" %in% nms1)
+  expect_true("__magrittr_caller_env" %in% nms2)
+
+  fn <- function(.) parent.frame()
+  nms3 <- mtcars %>% { } %>% identity() %>% fn() %>% ls()
+  expect_true("__magrittr_caller_env" %in% nms3)
+})


### PR DESCRIPTION
Addresses https://github.com/tidyverse/magrittr/issues/141

This creates a reference to the caller environment in the magrittr frame. This reference is stored in an object called `__magrittr_caller_env`.

We've ended up downplaying the tidyeval `.env` pronoun, but this might be useful for other purposes, e.g. https://github.com/tidyverse/dplyr/issues/2726

The first commit removes `enclos` arguments in `eval()` calls as those are ignored when `envir` is an environment.