### PR TITLE
Allow using vectors of indices in `debug_fseq`

### DIFF
--- a/R/debug_pipe.R
+++ b/R/debug_pipe.R
@@ -27,7 +27,7 @@ debug_fseq <- function(fseq, ...)
 {
   is_valid_index <- function(i) i %in% 1:length(functions(fseq))
 
-  indices <- list(...)
+  indices <- as.list(...)
     if (!any(vapply(indices, is.numeric, logical(1L))) ||
         !any(vapply(indices, is_valid_index, logical(1L))))
       stop("Index or indices invalid.", call. = FALSE)

--- a/R/debug_pipe.R
+++ b/R/debug_pipe.R
@@ -27,7 +27,7 @@ debug_fseq <- function(fseq, ...)
 {
   is_valid_index <- function(i) i %in% 1:length(functions(fseq))
 
-  indices <- as.list(...)
+  indices <- unlist(list(...))
     if (!any(vapply(indices, is.numeric, logical(1L))) ||
         !any(vapply(indices, is_valid_index, logical(1L))))
       stop("Index or indices invalid.", call. = FALSE)


### PR DESCRIPTION
This change preserves current functionality in `debug_fseq` (including multiple indices in the unmatched parameters, e.g. `debug_fseq(a, 1, 2, 3)`), while allowing to use vectors to specify the indices (e.g. `debug_fseq(a, 1, 2:3)`).

This fixes #149 and improves functionality by enabling idioms such as `debug_fseq(a, 1:length(functions(a)))` to automate selection of components to debug.