### PR TITLE
use seq_along(x) instead of 1:length(x)

### DIFF
--- a/R/debug_pipe.R
+++ b/R/debug_pipe.R
@@ -25,7 +25,7 @@ debug_pipe <- function(x)
 #' @export
 debug_fseq <- function(fseq, ...)
 {
-  is_valid_index <- function(i) i %in% 1:length(functions(fseq))
+  is_valid_index <- function(i) i %in% seq_along(functions(fseq))
 
   indices <- list(...)
     if (!any(vapply(indices, is.numeric, logical(1L))) ||
@@ -39,7 +39,7 @@ debug_fseq <- function(fseq, ...)
 #' @export
 undebug_fseq <- function(fseq)
 {
-  for (i in 1:length(functions(fseq)))
+  for (i in seq_along(functions(fseq)))
     if (isdebugged(functions(fseq)[[i]])) 
       undebug(functions(fseq)[[i]])
 }

--- a/R/functions.R
+++ b/R/functions.R
@@ -26,7 +26,7 @@ print.fseq <- function(x, ...)
   flist <- functions(x)
 
   cat("Functional sequence with the following components:\n\n")
-  lapply(1:length(flist), 
+  lapply(seq_along(flist), 
       function(i) cat(" ", i, ". ", deparse(body(flist[[i]])), "\n", sep = ""))
   cat("\nUse 'functions' to extract the individual functions.", "\n")
   x

--- a/R/pipe.R
+++ b/R/pipe.R
@@ -20,7 +20,7 @@ pipe <- function()
 
     # Create the list of functions defined by the right-hand sides.
     env[["_function_list"]] <- 
-      lapply(1:length(rhss), 
+      lapply(seq_along(rhss), 
              function(i) wrap_function(rhss[[i]], pipes[[i]], parent))
 
     # Create a function which applies each of the above functions in turn.


### PR DESCRIPTION
prefer the more robust `seq_along(x)` over `1:length(x)`