### PR TITLE
Fix @seealso link in %$%, tweak unit tests to eliminate deprecation warning from 'is_true()'

### DIFF
--- a/R/pipe.R
+++ b/R/pipe.R
@@ -268,7 +268,7 @@ pipe <- function()
 #' of the call. This operator exposes the contents of the left-hand side object
 #' to the expression on the right to give a similar benefit, see the examples.
 
-#' @seealso \code{\link{\%>\%}}, \code{\link{\%<>\%}}, \code{\link{\%$\%}}
+#' @seealso \code{\link{\%>\%}}, \code{\link{\%<>\%}}, \code{\link{\%T>\%}}
 #' 
 #' @examples
 #' iris %>%

--- a/man/exposition.Rd
+++ b/man/exposition.Rd
@@ -31,5 +31,5 @@ data.frame(z = rnorm(100)) \%$\%
   
 }
 \seealso{
-\code{\link{\%>\%}}, \code{\link{\%<>\%}}, \code{\link{\%$\%}}
+\code{\link{\%>\%}}, \code{\link{\%<>\%}}, \code{\link{\%T>\%}}
 }

--- a/tests/testthat/test-multiple-arguments.r
+++ b/tests/testthat/test-multiple-arguments.r
@@ -40,7 +40,7 @@ test_that("placement of lhs is correct in different situations", {
   expect_that(case1c, is_equivalent_to(case0c))
   
   # several placeholder dots
-  expect_that(iris %>% identical(., .), is_true())
+  expect_true(iris %>% identical(., .))
   
   
   # "indirect" function expressions 


### PR DESCRIPTION
Fixes incorrect `@seealso` link in `%$%` documentation.  Should point to `%T>` instead of `%$%`.  

To get unit tests fully passing I tweaked unit tests to eliminate deprecation warning from use of `is_true()`.