### PR TITLE
add alias for Encoding

### DIFF
--- a/R/aliases.R
+++ b/R/aliases.R
@@ -33,6 +33,7 @@
 #' \code{set_class}          \tab \code{`class<-`} \cr
 #' \code{set_attributes}     \tab \code{`attributes<-`} \cr
 #' \code{set_attr }          \tab \code{`attr<-`} \cr
+#' \code{set_encoding }      \tab \code{`Encoding<-`} \cr
 #' }
 #'
 #' @usage NULL
@@ -200,4 +201,7 @@ set_attr <- `attr<-`
 #' @export
 set_attributes <- `attributes<-`
 
-
+#' @rdname aliases
+#' @usage NULL
+#' @export
+set_encoding <- `Encoding<-`


### PR DESCRIPTION
Hi, just added an Alias for `Encoding<-`.

Makes it more concise for me working *across* multiple columns.
```
set_encoding <- `Encoding<-`

  tab = tab %>%
    mutate(across(c(col_a, col_b),
                  set_encoding, "UTF-8"))
```
compared to
```
   tab = tab %>% 
     mutate(across(c(col_a, col_b),
                  function(x) {
                    Encoding(x) <- "UTF-8"
                    return(x)
                  })
           )
```
Thanks, Christoph