### PR TITLE
Add test for pipe with lazy evaluation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # magrittr 1.5.0.9000
 
+## Bug fixes
+
+* Fix usage of the pipe with lazy evaluation (#195,
+  commit: 565eb9a6111fa432ab33284d13d59405621926a3)
+
 # magrittr 1.5
 
 ## New features

--- a/tests/testthat/test-single-argument.r
+++ b/tests/testthat/test-single-argument.r
@@ -16,3 +16,9 @@ test_that("%>% works as expected with and without parentheses and placeholder", 
   expect_that(some_x %>% dnormsd(5), throws_error())
   expect_that(some_x %>% function(x) {x} %>% sin, throws_error())
 })
+
+test_that("test pipe with lazy evaluation #195", {
+  gen <- function(x) function() eval(quote(x))
+  fn <- 1 %>% gen()
+  expect_equal(fn(), 1)
+})


### PR DESCRIPTION
Closes #195. The test, inspired on @lionel-'s issue already passed on master. I bisected the issue and it was fixed on 565eb9a6111fa432ab33284d13d59405621926a3. 

The test fails on the magrittr 1.5 source code as it is now available on CRAN, so maybe it's time for a new magrittr release that includes this bugfix?

I came across this issue through the stackoverflow question: https://stackoverflow.com/questions/61834248/r-piping-input-to-a-function-factory/61836228#61836228
