### PR TITLE
Fix visibility forwarding of `%$%` on old R versions

### DIFF
--- a/R/pipe.R
+++ b/R/pipe.R
@@ -219,6 +219,7 @@ pipe_nested <- function(lhs, rhs) {
   lhs <- substitute(lhs)
   rhs <- substitute(rhs)
   kind <- 2L
+  lazy <- TRUE
   env <- parent.frame()
   .External2(magrittr_pipe)
 }
@@ -249,6 +250,7 @@ pipe_nested <- function(lhs, rhs) {
   lhs <- substitute(lhs)
   rhs <- substitute(rhs)
   kind <- 3L
+  lazy <- TRUE
   env <- parent.frame()
   .External2(magrittr_pipe)
 }
@@ -282,6 +284,7 @@ pipe_nested <- function(lhs, rhs) {
   lhs <- substitute(lhs)
   rhs <- substitute(rhs)
   kind <- 4L
+  lazy <- TRUE
   env <- parent.frame()
   .External2(magrittr_pipe)
 }

--- a/tests/testthat/test-pipe.R
+++ b/tests/testthat/test-pipe.R
@@ -103,3 +103,15 @@ test_that("visibility is forwarded", {
     list(value = mtcars$cyl, visible = FALSE)
   )
 })
+
+test_that("`%<>%` always returns invisibly", {
+  foo <- 1
+  expect_equal(
+    withVisible(foo %<>% add(1) %>% identity()),
+    list(value = 2, visible = FALSE)
+  )
+  expect_equal(
+    withVisible(foo %<>% add(1) %>% invisible()),
+    list(value = 3, visible = FALSE)
+  )
+})

--- a/tests/testthat/test-pipe.R
+++ b/tests/testthat/test-pipe.R
@@ -41,6 +41,12 @@ test_that("lazy pipe evaluates expressions lazily (#120)", {
    ignore <- function(...) NA
    out <- stop("foo") %>% identity() %>% ignore()
    expect_identical(out, NA)
+
+   out <- stop("foo") %T>% identity() %>% ignore()
+   expect_identical(out, NA)
+
+   out %<>% stop() %>% ignore()
+   expect_identical(out, NA)
 })
 
 test_that("lazy pipe evaluates `.` in correct environments", {
@@ -68,4 +74,19 @@ test_that("allow trailing return for backward compatibility", {
 
   f <- function() 1 %>% identity() %>% return()
   expect_identical(f(), 1)
+})
+
+test_that("visibility is forwarded", {
+  expect_equal(
+    withVisible(mtcars %>% with(invisible(cyl))),
+    list(value = mtcars$cyl, visible = FALSE)
+  )
+  expect_equal(
+    withVisible(mtcars %$% invisible(cyl)),
+    list(value = mtcars$cyl, visible = FALSE)
+  )
+  expect_equal(
+    withVisible(mtcars %T>% identity %>% with(invisible(cyl))),
+    list(value = mtcars$cyl, visible = FALSE)
+  )
 })

--- a/tests/testthat/test-pipe.R
+++ b/tests/testthat/test-pipe.R
@@ -78,7 +78,20 @@ test_that("allow trailing return for backward compatibility", {
 
 test_that("visibility is forwarded", {
   expect_equal(
-    withVisible(mtcars %>% with(invisible(cyl))),
+    withVisible(mtcars %>% { identity(.$cyl) }),
+    list(value = mtcars$cyl, visible = TRUE)
+  )
+  expect_equal(
+    withVisible(mtcars %$% cyl),
+    list(value = mtcars$cyl, visible = TRUE)
+  )
+  expect_equal(
+    withVisible(mtcars %T>% identity() %>% { identity(.$cyl) }),
+    list(value = mtcars$cyl, visible = TRUE)
+  )
+
+  expect_equal(
+    withVisible(mtcars %>% { invisible(.$cyl) }),
     list(value = mtcars$cyl, visible = FALSE)
   )
   expect_equal(
@@ -86,7 +99,7 @@ test_that("visibility is forwarded", {
     list(value = mtcars$cyl, visible = FALSE)
   )
   expect_equal(
-    withVisible(mtcars %T>% identity %>% with(invisible(cyl))),
+    withVisible(mtcars %T>% identity() %>% { invisible(.$cyl) }),
     list(value = mtcars$cyl, visible = FALSE)
   )
 })


### PR DESCRIPTION
By making it follow the lazy path. Closes #226. It failed because the eager code path cleans up `.`. On older R versions, this calls back into the R-level `rm()` function which returns invisibly. On 4.0 there was no issue because we delete the binding with the new C-level API. This is worked around by following the lazy path which is more appropriate anyway.

Also make lazy the other pipes `%T>` and `%<>%`.