### PR TITLE
Release 2.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ Description: Provides a mechanism for chaining commands with a
     For more information, see package vignette.  To quote Rene Magritte,
     "Ceci n'est pas un pipe."
 License: MIT + file LICENSE
-URL: http://magrittr.tidyverse.org,
+URL:
+    https://magrittr.tidyverse.org,
     https://github.com/tidyverse/magrittr
 BugReports: https://github.com/tidyverse/magrittr/issues
 Suggests: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: magrittr
 Title: A Forward-Pipe Operator for R
-Version: 1.5.0.9000
+Version: 2.0.0
 Authors@R: 
     c(person(given = "Stefan Milton",
              family = "Bache",

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,17 +25,22 @@ warning("bar") %>% suppressWarnings()
 
 The pipe rewrite should generally not affect your code. We have
 checked magrittr on 2800 CRAN packages and found only a dozen of
-failures.
+failures. The development version of magrittr has been advertised on
+social media for a 3 months trial period, and no major issues were
+reported. However, there are some corner cases that might require
+updating your code. Below is a report of the backward
+incompatibilities we found in real code to help you transition, should
+you find an issue in your code.
 
 
 ### Behaviour of `return()` in a pipeline
 
-The behaviour of `return()` within pipe expressions was sort of
-undefined. Should it return from the current pipe expression, from the
-whole pipeline, or from the enclosing function? The behaviour that
-makes the most sense is to return from the enclosing
-function. However, we can't make this work easily with the new
-implementation, and so calling `return()` is now an error.
+In previous versions of magrittr, the behaviour of `return()` within
+pipe expressions was undefined. Should it return from the current pipe
+expression, from the whole pipeline, or from the enclosing function?
+The behaviour that makes the most sense is to return from the
+enclosing function. However, we can't make this work easily with the
+new implementation, and so calling `return()` is now an error.
 
 ```r
 my_function <- function(x) {
@@ -75,7 +80,7 @@ calls as this is a common occurrence in packages:
 ```
 
 Note however that this only returns from the pipeline, not the
-enclosing function:
+enclosing function (which is the historical behaviour):
 
 ```r
 my_function <- function() {

--- a/README.Rmd
+++ b/README.Rmd
@@ -18,7 +18,7 @@ library(magrittr)
 <!-- badges: start -->
 [![CRAN status](https://www.r-pkg.org/badges/version/magrittr)](https://cran.r-project.org/package=magrittr)
 [![Codecov test coverage](https://codecov.io/gh/tidyverse/magrittr/branch/master/graph/badge.svg)](https://codecov.io/gh/tidyverse/magrittr?branch=master)
-[![R build status](https://github.com/smbache/magrittr/workflows/R-CMD-check/badge.svg)](https://github.com/smbache/magrittr/actions)
+[![R build status](https://github.com/tidyverse/magrittr/workflows/R-CMD-check/badge.svg)](https://github.com/tidyverse/magrittr/actions)
 <!-- badges: end -->
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ status](https://www.r-pkg.org/badges/version/magrittr)](https://cran.r-project.o
 [![Codecov test
 coverage](https://codecov.io/gh/tidyverse/magrittr/branch/master/graph/badge.svg)](https://codecov.io/gh/tidyverse/magrittr?branch=master)
 [![R build
-status](https://github.com/smbache/magrittr/workflows/R-CMD-check/badge.svg)](https://github.com/smbache/magrittr/actions)
+status](https://github.com/tidyverse/magrittr/workflows/R-CMD-check/badge.svg)](https://github.com/tidyverse/magrittr/actions)
 <!-- badges: end -->
 
 ## Overview

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,33 +1,15 @@
-## Response to CRAN comments on last submit
-
-* Another attempt at getting title casing correct.
-* Added a slightly longer description to the DESCRIPTION file
-* Added quotation marks to the Treachery of Images quotation.
-* The quotation is kept as it is part og the package's image. 
-  I hope you will respect this decision.
-* Added NEWS.md to .Rbuildignore
 
 ## Test environments
 
-* local: darwin15.6.0-3.5.1
-* travis: 3.1, 3.2, 3.3, oldrel, release, devel
-* r-hub: windows-x86_64-devel, ubuntu-gcc-release, fedora-clang-devel
-* win-builder: windows-x86_64-devel
+* local: macOS, r-release
+* travis: 3.3, 3.4, 3.5, 3.6, 4.0, r-devel
+* r-hub: 6 platforms including sanitizer checks and rchk
+* win-builder: r-release and r-devel
 
 ## R CMD check results
-There were no ERRORs or WARNINGs. 
 
-I experience this NOTE, when using devtools::release, but not
-when I check the package as usual:
-
-* checking CRAN incoming feasibility ... NOTE
-Maintainer: 'Stefan Milton Bache <stefan@stefanbache.dk>'
-Components with restrictions and base license permitting such:
-  MIT + file LICENSE
-File 'LICENSE':
-  YEAR: 2014
-  COPYRIGHT HOLDER: Stefan Milton Bache and Hadley Wickham
+There were no ERRORs, WARNINGs, or NOTEs.
 
 ## Downstream dependencies
-I have also run R CMD check on downstream dependencies of magrittr. 
-There were only notes unrelated to magrittr.
+
+Whe have run R CMD check on reverse dependencies of magrittr, dplyr, tidyr, and purrr. Maintainers of failing packages were notified or offered fixes two months ago. There are 5 remaining failures in our latest run.

--- a/man/magrittr-package.Rd
+++ b/man/magrittr-package.Rd
@@ -49,7 +49,7 @@ the_data <-
 \seealso{
 Useful links:
 \itemize{
-  \item \url{http://magrittr.tidyverse.org}
+  \item \url{https://magrittr.tidyverse.org}
   \item \url{https://github.com/tidyverse/magrittr}
   \item Report bugs at \url{https://github.com/tidyverse/magrittr/issues}
 }

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -1,19 +1,44 @@
 # Revdeps
 
-## New problems (12)
+## Failed to check (26)
 
-|package                                     |version |error  |warning |note |
-|:-------------------------------------------|:-------|:------|:-------|:----|
-|[datamaps](problems.md#datamaps)            |0.0.3   |__+1__ |        |     |
-|[detrendr](problems.md#detrendr)            |0.6.8   |__+1__ |        |2    |
-|[dragon](problems.md#dragon)                |1.0.1   |__+1__ |        |1    |
-|[finalfit](problems.md#finalfit)            |1.0.2   |__+1__ |        |     |
-|[nandb](problems.md#nandb)                  |2.0.7   |__+1__ |        |     |
-|[nlmixr](problems.md#nlmixr)                |1.1.1-9 |__+1__ |        |2    |
-|[r2dii.analysis](problems.md#r2diianalysis) |0.0.1   |__+1__ |        |     |
-|[rcrtan](problems.md#rcrtan)                |0.1.1   |__+1__ |        |     |
-|[rlang](problems.md#rlang)                  |0.4.7   |__+1__ |        |     |
-|[taber](problems.md#taber)                  |0.1.0   |__+1__ |        |     |
-|[tidytidbits](problems.md#tidytidbits)      |0.2.2   |__+1__ |        |     |
-|[xpose](problems.md#xpose)                  |0.4.11  |__+2__ |        |     |
+|package                    |version |error  |warning |note |
+|:--------------------------|:-------|:------|:-------|:----|
+|NA                         |?       |       |        |     |
+|NA                         |?       |       |        |     |
+|CB2                        |?       |       |        |     |
+|cbar                       |?       |       |        |     |
+|diceR                      |?       |       |        |     |
+|dimRed                     |?       |       |        |     |
+|ESTER                      |0.2.0   |1      |        |     |
+|NA                         |?       |       |        |     |
+|ggmsa                      |?       |       |        |     |
+|jstor                      |?       |       |        |     |
+|mapdeck                    |0.3.4   |1      |        |     |
+|NA                         |?       |       |        |     |
+|osmplotr                   |?       |       |        |     |
+|NA                         |?       |       |        |     |
+|NA                         |?       |       |        |     |
+|NA                         |?       |       |        |     |
+|precautionary              |0.1-5   |1      |        |     |
+|NA                         |?       |       |        |     |
+|RichR                      |?       |       |        |     |
+|[ripe](failures.md#ripe)   |0.1.0   |__+1__ |        |     |
+|NA                         |?       |       |        |     |
+|NA                         |?       |       |        |     |
+|smartdata                  |?       |       |        |     |
+|SMITIDvisu                 |?       |       |        |     |
+|spectralAnalysis           |?       |       |        |     |
+|[torch](failures.md#torch) |0.1.1   |__+1__ |        |-1   |
+
+## New problems (6)
+
+|package                                  |version |error  |warning |note |
+|:----------------------------------------|:-------|:------|:-------|:----|
+|[datamaps](problems.md#datamaps)         |0.0.3   |__+1__ |        |     |
+|[jqr](problems.md#jqr)                   |1.1.0   |__+2__ |        |     |
+|[rcrtan](problems.md#rcrtan)             |0.1.1   |__+1__ |        |     |
+|[reproducible](problems.md#reproducible) |1.2.1   |__+2__ |        |     |
+|[sketch](problems.md#sketch)             |1.0.3   |__+2__ |        |     |
+|[tidytidbits](problems.md#tidytidbits)   |0.2.2   |__+1__ |        |     |
 

--- a/revdep/failures.md
+++ b/revdep/failures.md
@@ -1,1 +1,1551 @@
-*Wow, no problems at all. :)*
+# NA
+
+<details>
+
+* Version: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
+
+Run `cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
+# NA
+
+<details>
+
+* Version: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
+
+Run `cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
+# CB2
+
+<details>
+
+* Version: 1.3.4
+* Source code: https://github.com/cran/CB2
+* Date/Publication: 2020-07-24 09:42:24 UTC
+* Number of recursive dependencies: 106
+
+Run `cloud_details(, "CB2")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/CB2/new/CB2.Rcheck’
+* using R version 3.6.3 (2020-02-29)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘CB2/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘CB2’ version ‘1.3.4’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘metap’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/CB2/old/CB2.Rcheck’
+* using R version 3.6.3 (2020-02-29)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘CB2/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘CB2’ version ‘1.3.4’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘metap’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+
+```
+# cbar
+
+<details>
+
+* Version: 0.1.3
+* Source code: https://github.com/cran/cbar
+* URL: https://github.com/zedoul/cbar
+* BugReports: https://github.com/zedoul/cbar/issues
+* Date/Publication: 2017-10-24 13:20:22 UTC
+* Number of recursive dependencies: 67
+
+Run `cloud_details(, "cbar")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/cbar/new/cbar.Rcheck’
+* using R version 3.6.3 (2020-02-29)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘cbar/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘cbar’ version ‘0.1.3’
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'Boom', 'bsts'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/cbar/old/cbar.Rcheck’
+* using R version 3.6.3 (2020-02-29)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘cbar/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘cbar’ version ‘0.1.3’
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'Boom', 'bsts'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+
+```
+# diceR
+
+<details>
+
+* Version: 1.0.0
+* Source code: https://github.com/cran/diceR
+* URL: https://github.com/AlineTalhouk/diceR, https://alinetalhouk.github.io/diceR
+* BugReports: https://github.com/AlineTalhouk/diceR/issues
+* Date/Publication: 2020-07-07 22:30:02 UTC
+* Number of recursive dependencies: 143
+
+Run `cloud_details(, "diceR")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/diceR/new/diceR.Rcheck’
+* using R version 3.6.3 (2020-02-29)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘diceR/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘diceR’ version ‘1.0.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘NMF’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/diceR/old/diceR.Rcheck’
+* using R version 3.6.3 (2020-02-29)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘diceR/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘diceR’ version ‘1.0.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘NMF’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+
+```
+# dimRed
+
+<details>
+
+* Version: 0.2.3
+* Source code: https://github.com/cran/dimRed
+* URL: https://github.com/gdkrmr/dimRed
+* Date/Publication: 2019-05-08 08:10:07 UTC
+* Number of recursive dependencies: 140
+
+Run `cloud_details(, "dimRed")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/dimRed/new/dimRed.Rcheck’
+* using R version 3.6.3 (2020-02-29)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘dimRed/DESCRIPTION’ ... OK
+* this is package ‘dimRed’ version ‘0.2.3’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package suggested but not available: ‘NMF’
+
+The suggested packages are required for a complete check.
+Checking can be attempted without them by setting the environment
+variable _R_CHECK_FORCE_SUGGESTS_ to a false value.
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/dimRed/old/dimRed.Rcheck’
+* using R version 3.6.3 (2020-02-29)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘dimRed/DESCRIPTION’ ... OK
+* this is package ‘dimRed’ version ‘0.2.3’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package suggested but not available: ‘NMF’
+
+The suggested packages are required for a complete check.
+Checking can be attempted without them by setting the environment
+variable _R_CHECK_FORCE_SUGGESTS_ to a false value.
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+
+```
+# ESTER
+
+<details>
+
+* Version: 0.2.0
+* Source code: https://github.com/cran/ESTER
+* URL: https://github.com/lnalborczyk/ESTER
+* BugReports: https://github.com/lnalborczyk/ESTER/issues
+* Date/Publication: 2017-12-10 14:21:14 UTC
+* Number of recursive dependencies: 164
+
+Run `cloud_details(, "ESTER")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘ESTER’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/tmp/workdir/ESTER/new/ESTER.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘ESTER’ ...
+** package ‘ESTER’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Warning: namespace ‘rstan’ is not available and has been replaced
+by .GlobalEnv when processing object ‘’
+Error in loadNamespace(j <- imp[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) : 
+  there is no package called ‘rstan’
+Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
+Execution halted
+ERROR: lazy loading failed for package ‘ESTER’
+* removing ‘/tmp/workdir/ESTER/new/ESTER.Rcheck/ESTER’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘ESTER’ ...
+** package ‘ESTER’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Warning: namespace ‘rstan’ is not available and has been replaced
+by .GlobalEnv when processing object ‘’
+Error in loadNamespace(j <- imp[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) : 
+  there is no package called ‘rstan’
+Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
+Execution halted
+ERROR: lazy loading failed for package ‘ESTER’
+* removing ‘/tmp/workdir/ESTER/old/ESTER.Rcheck/ESTER’
+
+```
+# NA
+
+<details>
+
+* Version: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
+
+Run `cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
+# ggmsa
+
+<details>
+
+* Version: 0.0.4
+* Source code: https://github.com/cran/ggmsa
+* Date/Publication: 2020-05-28 10:50:10 UTC
+* Number of recursive dependencies: 82
+
+Run `cloud_details(, "ggmsa")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/ggmsa/new/ggmsa.Rcheck’
+* using R version 3.6.3 (2020-02-29)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘ggmsa/DESCRIPTION’ ... OK
+* this is package ‘ggmsa’ version ‘0.0.4’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘Biostrings’
+
+Packages suggested but not available: 'ggtree', 'seqmagick'
+
+The suggested packages are required for a complete check.
+Checking can be attempted without them by setting the environment
+variable _R_CHECK_FORCE_SUGGESTS_ to a false value.
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/ggmsa/old/ggmsa.Rcheck’
+* using R version 3.6.3 (2020-02-29)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘ggmsa/DESCRIPTION’ ... OK
+* this is package ‘ggmsa’ version ‘0.0.4’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘Biostrings’
+
+Packages suggested but not available: 'ggtree', 'seqmagick'
+
+The suggested packages are required for a complete check.
+Checking can be attempted without them by setting the environment
+variable _R_CHECK_FORCE_SUGGESTS_ to a false value.
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+
+```
+# jstor
+
+<details>
+
+* Version: 0.3.9
+* Source code: https://github.com/cran/jstor
+* URL: https://github.com/ropensci/jstor, https://docs.ropensci.org/jstor
+* BugReports: https://github.com/ropensci/jstor/issues
+* Date/Publication: 2020-06-04 04:50:03 UTC
+* Number of recursive dependencies: 74
+
+Run `cloud_details(, "jstor")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/jstor/old/jstor.Rcheck’
+* using R version 3.6.3 (2020-02-29)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘jstor/DESCRIPTION’ ... OK
+* this is package ‘jstor’ version ‘0.3.9’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... OK
+* checking if this is a source package ... OK
+* checking if there is a namespace ... OK
+* checking for executable files ... OK
+* checking for hidden files and directories ... OK
+* checking for portable file names ... OK
+* checking for sufficient/correct file permissions ... OK
+* checking whether package ‘jstor’ can be installed ... OK
+* checking installed package size ... OK
+* checking package directory ... OK
+* checking ‘build’ directory ... OK
+* checking DESCRIPTION meta-information ... OK
+* checking top-level files ... OK
+* checking for left-over files ... OK
+* checking index information ... OK
+* checking package subdirectories ... OK
+* checking R files for non-ASCII characters ... OK
+* checking R files for syntax errors ... OK
+* checking whether the package can be loaded ... OK
+* checking whether the package can be loaded with stated dependencies ... OK
+* checking whether the package can be unloaded cleanly ... OK
+* checking whether the namespace can be loaded with stated dependencies ... OK
+* checking whether the namespace can be unloaded cleanly ... OK
+* checking loading without being on the library search path ... OK
+* checking dependencies in R code ... OK
+* checking S3 generic/method consistency ... OK
+* checking replacement functions ... OK
+* checking foreign function calls ... OK
+* checking R code for possible problems ... OK
+* checking Rd files ... OK
+* checking Rd metadata ... OK
+* checking Rd cross-references ... OK
+* checking for missing documentation entries ... OK
+* checking for code/documentation mismatches ... OK
+* checking Rd \usage sections ... OK
+* checking Rd contents ... OK
+* checking for unstated dependencies in examples ... OK
+* checking R/sysdata.rda ... OK
+* checking installed files from ‘inst/doc’ ... OK
+* checking files in ‘vignettes’ ... OK
+* checking examples ... OK
+* checking for unstated dependencies in ‘tests’ ... OK
+* checking tests ...
+
+
+
+
+
+```
+# mapdeck
+
+<details>
+
+* Version: 0.3.4
+* Source code: https://github.com/cran/mapdeck
+* URL: https://symbolixau.github.io/mapdeck/articles/mapdeck.html
+* BugReports: https://github.com/SymbolixAU/mapdeck/issues
+* Date/Publication: 2020-09-04 05:22:10 UTC
+* Number of recursive dependencies: 75
+
+Run `cloud_details(, "mapdeck")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘mapdeck’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/tmp/workdir/mapdeck/new/mapdeck.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘mapdeck’ ...
+** package ‘mapdeck’ successfully unpacked and MD5 sums checked
+** using staged installation
+** libs
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG -DSTRICT_R_HEADERS -DBOOST_NO_AUTO_PTR -I"/usr/local/lib/R/site-library/BH/include" -I"/usr/local/lib/R/site-library/colourvalues/include" -I"/usr/local/lib/R/site-library/geojsonsf/include" -I"/usr/local/lib/R/site-library/geometries/include" -I"/usr/local/lib/R/site-library/jsonify/include" -I"/usr/local/lib/R/site-library/rapidjsonr/include" -I"/usr/local/lib/R/site-library/Rcpp/include" -I"/usr/local/lib/R/site-library/sfheaders/include" -I"/usr/local/lib/R/site-library/spatialwidget/include"  -I../inst/include -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c RcppExports.cpp -o RcppExports.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG -DSTRICT_R_HEADERS -DBOOST_NO_AUTO_PTR -I"/usr/local/lib/R/site-library/BH/include" -I"/usr/local/lib/R/site-library/colourvalues/include" -I"/usr/local/lib/R/site-library/geojsonsf/include" -I"/usr/local/lib/R/site-library/geometries/include" -I"/usr/local/lib/R/site-library/jsonify/include" -I"/usr/local/lib/R/site-library/rapidjsonr/include" -I"/usr/local/lib/R/site-library/Rcpp/include" -I"/usr/local/lib/R/site-library/sfheaders/include" -I"/usr/local/lib/R/site-library/spatialwidget/include"  -I../inst/include -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c aggregate.cpp -o aggregate.o
+/tmp/ccqSUMiy.s: Assembler messages:
+/tmp/ccqSUMiy.s: Fatal error: can't close aggregate.o: No space left on device
+make: *** [/usr/lib/R/etc/Makeconf:177: aggregate.o] Error 1
+ERROR: compilation failed for package ‘mapdeck’
+* removing ‘/tmp/workdir/mapdeck/new/mapdeck.Rcheck/mapdeck’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘mapdeck’ ...
+** package ‘mapdeck’ successfully unpacked and MD5 sums checked
+** using staged installation
+** libs
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG -DSTRICT_R_HEADERS -DBOOST_NO_AUTO_PTR -I"/usr/local/lib/R/site-library/BH/include" -I"/usr/local/lib/R/site-library/colourvalues/include" -I"/usr/local/lib/R/site-library/geojsonsf/include" -I"/usr/local/lib/R/site-library/geometries/include" -I"/usr/local/lib/R/site-library/jsonify/include" -I"/usr/local/lib/R/site-library/rapidjsonr/include" -I"/usr/local/lib/R/site-library/Rcpp/include" -I"/usr/local/lib/R/site-library/sfheaders/include" -I"/usr/local/lib/R/site-library/spatialwidget/include"  -I../inst/include -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c RcppExports.cpp -o RcppExports.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG -DSTRICT_R_HEADERS -DBOOST_NO_AUTO_PTR -I"/usr/local/lib/R/site-library/BH/include" -I"/usr/local/lib/R/site-library/colourvalues/include" -I"/usr/local/lib/R/site-library/geojsonsf/include" -I"/usr/local/lib/R/site-library/geometries/include" -I"/usr/local/lib/R/site-library/jsonify/include" -I"/usr/local/lib/R/site-library/rapidjsonr/include" -I"/usr/local/lib/R/site-library/Rcpp/include" -I"/usr/local/lib/R/site-library/sfheaders/include" -I"/usr/local/lib/R/site-library/spatialwidget/include"  -I../inst/include -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c aggregate.cpp -o aggregate.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG -DSTRICT_R_HEADERS -DBOOST_NO_AUTO_PTR -I"/usr/local/lib/R/site-library/BH/include" -I"/usr/local/lib/R/site-library/colourvalues/include" -I"/usr/local/lib/R/site-library/geojsonsf/include" -I"/usr/local/lib/R/site-library/geometries/include" -I"/usr/local/lib/R/site-library/jsonify/include" -I"/usr/local/lib/R/site-library/rapidjsonr/include" -I"/usr/local/lib/R/site-library/Rcpp/include" -I"/usr/local/lib/R/site-library/sfheaders/include" -I"/usr/local/lib/R/site-library/spatialwidget/include"  -I../inst/include -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c geojson.cpp -o geojson.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG -DSTRICT_R_HEADERS -DBOOST_NO_AUTO_PTR -I"/usr/local/lib/R/site-library/BH/include" -I"/usr/local/lib/R/site-library/colourvalues/include" -I"/usr/local/lib/R/site-library/geojsonsf/include" -I"/usr/local/lib/R/site-library/geometries/include" -I"/usr/local/lib/R/site-library/jsonify/include" -I"/usr/local/lib/R/site-library/rapidjsonr/include" -I"/usr/local/lib/R/site-library/Rcpp/include" -I"/usr/local/lib/R/site-library/sfheaders/include" -I"/usr/local/lib/R/site-library/spatialwidget/include"  -I../inst/include -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c mesh.cpp -o mesh.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG -DSTRICT_R_HEADERS -DBOOST_NO_AUTO_PTR -I"/usr/local/lib/R/site-library/BH/include" -I"/usr/local/lib/R/site-library/colourvalues/include" -I"/usr/local/lib/R/site-library/geojsonsf/include" -I"/usr/local/lib/R/site-library/geometries/include" -I"/usr/local/lib/R/site-library/jsonify/include" -I"/usr/local/lib/R/site-library/rapidjsonr/include" -I"/usr/local/lib/R/site-library/Rcpp/include" -I"/usr/local/lib/R/site-library/sfheaders/include" -I"/usr/local/lib/R/site-library/spatialwidget/include"  -I../inst/include -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c od.cpp -o od.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG -DSTRICT_R_HEADERS -DBOOST_NO_AUTO_PTR -I"/usr/local/lib/R/site-library/BH/include" -I"/usr/local/lib/R/site-library/colourvalues/include" -I"/usr/local/lib/R/site-library/geojsonsf/include" -I"/usr/local/lib/R/site-library/geometries/include" -I"/usr/local/lib/R/site-library/jsonify/include" -I"/usr/local/lib/R/site-library/rapidjsonr/include" -I"/usr/local/lib/R/site-library/Rcpp/include" -I"/usr/local/lib/R/site-library/sfheaders/include" -I"/usr/local/lib/R/site-library/spatialwidget/include"  -I../inst/include -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c path.cpp -o path.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG -DSTRICT_R_HEADERS -DBOOST_NO_AUTO_PTR -I"/usr/local/lib/R/site-library/BH/include" -I"/usr/local/lib/R/site-library/colourvalues/include" -I"/usr/local/lib/R/site-library/geojsonsf/include" -I"/usr/local/lib/R/site-library/geometries/include" -I"/usr/local/lib/R/site-library/jsonify/include" -I"/usr/local/lib/R/site-library/rapidjsonr/include" -I"/usr/local/lib/R/site-library/Rcpp/include" -I"/usr/local/lib/R/site-library/sfheaders/include" -I"/usr/local/lib/R/site-library/spatialwidget/include"  -I../inst/include -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c point.cpp -o point.o
+/tmp/ccj1hTMJ.s: Assembler messages:
+/tmp/ccj1hTMJ.s: Fatal error: can't close point.o: No space left on device
+make: *** [/usr/lib/R/etc/Makeconf:177: point.o] Error 1
+ERROR: compilation failed for package ‘mapdeck’
+* removing ‘/tmp/workdir/mapdeck/old/mapdeck.Rcheck/mapdeck’
+
+```
+# NA
+
+<details>
+
+* Version: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
+
+Run `cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
+# osmplotr
+
+<details>
+
+* Version: 0.3.2
+* Source code: https://github.com/cran/osmplotr
+* URL: https://github.com/ropensci/osmplotr
+* BugReports: https://github.com/ropensci/osmplotr/issues
+* Date/Publication: 2018-12-19 13:40:03 UTC
+* Number of recursive dependencies: 120
+
+Run `cloud_details(, "osmplotr")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/osmplotr/new/osmplotr.Rcheck’
+* using R version 3.6.3 (2020-02-29)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘osmplotr/DESCRIPTION’ ... OK
+* this is package ‘osmplotr’ version ‘0.3.2’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘ggm’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/osmplotr/old/osmplotr.Rcheck’
+* using R version 3.6.3 (2020-02-29)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘osmplotr/DESCRIPTION’ ... OK
+* this is package ‘osmplotr’ version ‘0.3.2’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘ggm’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+
+```
+# NA
+
+<details>
+
+* Version: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
+
+Run `cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
+# NA
+
+<details>
+
+* Version: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
+
+Run `cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
+# NA
+
+<details>
+
+* Version: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
+
+Run `cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
+# precautionary
+
+<details>
+
+* Version: 0.1-5
+* Source code: https://github.com/cran/precautionary
+* URL: https://precisionmethods.guru/
+* Date/Publication: 2020-11-03 06:30:02 UTC
+* Number of recursive dependencies: 125
+
+Run `cloud_details(, "precautionary")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘precautionary’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/tmp/workdir/precautionary/new/precautionary.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘precautionary’ ...
+** package ‘precautionary’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** demo
+** exec
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘escalation’ in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]):
+ there is no package called ‘trialr’
+Error: package ‘escalation’ could not be loaded
+Execution halted
+ERROR: lazy loading failed for package ‘precautionary’
+* removing ‘/tmp/workdir/precautionary/new/precautionary.Rcheck/precautionary’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘precautionary’ ...
+** package ‘precautionary’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** demo
+** exec
+** inst
+** byte-compile and prepare package for lazy loading
+Error: package or namespace load failed for ‘escalation’ in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]):
+ there is no package called ‘trialr’
+Error: package ‘escalation’ could not be loaded
+Execution halted
+ERROR: lazy loading failed for package ‘precautionary’
+* removing ‘/tmp/workdir/precautionary/old/precautionary.Rcheck/precautionary’
+
+```
+# NA
+
+<details>
+
+* Version: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
+
+Run `cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
+# RichR
+
+<details>
+
+* Version: 1.0.0
+* Source code: https://github.com/cran/RichR
+* Date/Publication: 2019-02-22 14:00:03 UTC
+* Number of recursive dependencies: 39
+
+Run `cloud_details(, "RichR")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/RichR/new/RichR.Rcheck’
+* using R version 3.6.3 (2020-02-29)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘RichR/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘RichR’ version ‘1.0.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘metap’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/RichR/old/RichR.Rcheck’
+* using R version 3.6.3 (2020-02-29)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘RichR/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘RichR’ version ‘1.0.0’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘metap’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+
+```
+# ripe
+
+<details>
+
+* Version: 0.1.0
+* Source code: https://github.com/cran/ripe
+* URL: https://github.com/yonicd/ripe
+* BugReports: https://github.com/yonicd/ripe/issues
+* Date/Publication: 2019-12-06 10:10:02 UTC
+* Number of recursive dependencies: 59
+
+Run `cloud_details(, "ripe")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking whether package ‘ripe’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/tmp/workdir/ripe/new/ripe.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘ripe’ ...
+** package ‘ripe’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error in get("is_pipe", asNamespace("magrittr")) : 
+  object 'is_pipe' not found
+Error: unable to load R code in package ‘ripe’
+Execution halted
+ERROR: lazy loading failed for package ‘ripe’
+* removing ‘/tmp/workdir/ripe/new/ripe.Rcheck/ripe’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘ripe’ ...
+** package ‘ripe’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+** help
+*** installing help indices
+** building package indices
+** installing vignettes
+** testing if installed package can be loaded from temporary location
+** testing if installed package can be loaded from final location
+** testing if installed package keeps a record of temporary installation path
+* DONE (ripe)
+
+```
+# NA
+
+<details>
+
+* Version: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
+
+Run `cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
+# NA
+
+<details>
+
+* Version: NA
+* Source code: https://github.com/cran/NA
+* Number of recursive dependencies: 0
+
+Run `cloud_details(, "NA")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+
+
+
+
+
+
+```
+### CRAN
+
+```
+
+
+
+
+
+
+```
+# smartdata
+
+<details>
+
+* Version: 1.0.3
+* Source code: https://github.com/cran/smartdata
+* URL: http://github.com/ncordon/smartdata
+* BugReports: http://github.com/ncordon/smartdata/issues
+* Date/Publication: 2019-12-18 17:40:02 UTC
+* Number of recursive dependencies: 271
+
+Run `cloud_details(, "smartdata")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/smartdata/new/smartdata.Rcheck’
+* using R version 3.6.3 (2020-02-29)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘smartdata/DESCRIPTION’ ... OK
+* this is package ‘smartdata’ version ‘1.0.3’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘adaptiveGPCA’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/smartdata/old/smartdata.Rcheck’
+* using R version 3.6.3 (2020-02-29)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘smartdata/DESCRIPTION’ ... OK
+* this is package ‘smartdata’ version ‘1.0.3’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package required but not available: ‘adaptiveGPCA’
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+
+```
+# SMITIDvisu
+
+<details>
+
+* Version: 0.0.8
+* Source code: https://github.com/cran/SMITIDvisu
+* URL: https://informatique-mia.inrae.fr/biosp/anr-smitid-project/, https://gitlab.paca.inrae.fr/SMITID/visu/
+* Date/Publication: 2020-11-05 11:10:02 UTC
+* Number of recursive dependencies: 85
+
+Run `cloud_details(, "SMITIDvisu")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/SMITIDvisu/new/SMITIDvisu.Rcheck’
+* using R version 3.6.3 (2020-02-29)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘SMITIDvisu/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘SMITIDvisu’ version ‘0.0.8’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package suggested but not available: ‘SMITIDstruct’
+
+The suggested packages are required for a complete check.
+Checking can be attempted without them by setting the environment
+variable _R_CHECK_FORCE_SUGGESTS_ to a false value.
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/SMITIDvisu/old/SMITIDvisu.Rcheck’
+* using R version 3.6.3 (2020-02-29)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘SMITIDvisu/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘SMITIDvisu’ version ‘0.0.8’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Package suggested but not available: ‘SMITIDstruct’
+
+The suggested packages are required for a complete check.
+Checking can be attempted without them by setting the environment
+variable _R_CHECK_FORCE_SUGGESTS_ to a false value.
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+
+```
+# spectralAnalysis
+
+<details>
+
+* Version: 3.12.0
+* Source code: https://github.com/cran/spectralAnalysis
+* URL: http://www.openanalytics.eu
+* Date/Publication: 2018-06-12 14:30:39 UTC
+* Number of recursive dependencies: 118
+
+Run `cloud_details(, "spectralAnalysis")` for more info
+
+</details>
+
+## Error before installation
+
+### Devel
+
+```
+* using log directory ‘/tmp/workdir/spectralAnalysis/new/spectralAnalysis.Rcheck’
+* using R version 3.6.3 (2020-02-29)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘spectralAnalysis/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘spectralAnalysis’ version ‘3.12.0’
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'BiocGenerics', 'NMF'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+
+```
+### CRAN
+
+```
+* using log directory ‘/tmp/workdir/spectralAnalysis/old/spectralAnalysis.Rcheck’
+* using R version 3.6.3 (2020-02-29)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using options ‘--no-manual --no-build-vignettes’
+* checking for file ‘spectralAnalysis/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘spectralAnalysis’ version ‘3.12.0’
+* checking package namespace information ... OK
+* checking package dependencies ... ERROR
+Packages required but not available: 'BiocGenerics', 'NMF'
+
+See section ‘The DESCRIPTION file’ in the ‘Writing R Extensions’
+manual.
+* DONE
+Status: 1 ERROR
+
+
+
+
+
+
+```
+# torch
+
+<details>
+
+* Version: 0.1.1
+* Source code: https://github.com/cran/torch
+* URL: https://torch.mlverse.org/docs, https://github.com/mlverse/torch
+* BugReports: https://github.com/mlverse/torch/issues
+* Date/Publication: 2020-10-20 21:10:02 UTC
+* Number of recursive dependencies: 59
+
+Run `cloud_details(, "torch")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking whether package ‘torch’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/tmp/workdir/torch/new/torch.Rcheck/00install.out’ for details.
+    ```
+
+## Newly fixed
+
+*   checking installed package size ... NOTE
+    ```
+      installed size is 157.6Mb
+      sub-directories of 1Mb or more:
+        R       3.1Mb
+        help    2.8Mb
+        libs  151.2Mb
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘torch’ ...
+** package ‘torch’ successfully unpacked and MD5 sums checked
+** using staged installation
+** libs
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c RcppExports.cpp -o RcppExports.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c autograd.cpp -o autograd.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c contrib.cpp -o contrib.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c cuda.cpp -o cuda.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c device.cpp -o device.o
+In file included from device.cpp:2:
+torch_types.h:7: warning: "LANTERN_HOST_HANDLER" redefined
+    7 | #define LANTERN_HOST_HANDLER lantern_host_handler();
+      | 
+In file included from device.cpp:1:
+lantern/lantern.h:35: note: this is the location of the previous definition
+   35 | #define LANTERN_HOST_HANDLER
+      | 
+In file included from device.cpp:1:
+lantern/lantern.h: In function ‘bool lanternInit(const string&, std::string*)’:
+lantern/lantern.h:4097:6: note: variable tracking size limit exceeded with ‘-fvar-tracking-assignments’, retrying without
+ 4097 | bool lanternInit(const std::string &libPath, std::string *pError)
+      |      ^~~~~~~~~~~
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c dimname_list.cpp -o dimname_list.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c dtype.cpp -o dtype.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c gen-namespace.cpp -o gen-namespace.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c generator.cpp -o generator.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c indexing.cpp -o indexing.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c lantern.cpp -o lantern.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c layout.cpp -o layout.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c memory_format.cpp -o memory_format.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c nn_utils_rnn.cpp -o nn_utils_rnn.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c qscheme.cpp -o qscheme.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c quantization.cpp -o quantization.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c reduction.cpp -o reduction.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c save.cpp -o save.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c scalar.cpp -o scalar.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c storage.cpp -o storage.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c tensor.cpp -o tensor.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c tensor_list.cpp -o tensor_list.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c tensor_options.cpp -o tensor_options.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c utils.cpp -o utils.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c variable_list.cpp -o variable_list.o
+g++ -std=gnu++11 -shared -L/usr/lib/R/lib -Wl,-Bsymbolic-functions -Wl,-z,relro -o torch.so RcppExports.o autograd.o contrib.o cuda.o device.o dimname_list.o dtype.o gen-namespace.o generator.o indexing.o lantern.o layout.o memory_format.o nn_utils_rnn.o qscheme.o quantization.o reduction.o save.o scalar.o storage.o tensor.o tensor_list.o tensor_options.o utils.o variable_list.o -L/usr/lib/R/lib -lR
+Renaming torch lib to torchpkg
+"/usr/lib/R/bin/Rscript" "../tools/renamelib.R"
+installing to /tmp/workdir/torch/new/torch.Rcheck/00LOCK-torch/00new/torch/libs
+** R
+Warning in dir.create(outCodeDir) :
+  cannot create dir '/tmp/workdir/torch/new/torch.Rcheck/00LOCK-torch/00new/torch/R', reason 'No space left on device'
+Error in .install_package_code_files(".", instdir) : 
+  cannot open directory '/tmp/workdir/torch/new/torch.Rcheck/00LOCK-torch/00new/torch/R'
+ERROR: unable to collate and parse R files for package ‘torch’
+* removing ‘/tmp/workdir/torch/new/torch.Rcheck/torch’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘torch’ ...
+** package ‘torch’ successfully unpacked and MD5 sums checked
+** using staged installation
+** libs
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c RcppExports.cpp -o RcppExports.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c autograd.cpp -o autograd.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c contrib.cpp -o contrib.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c cuda.cpp -o cuda.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c device.cpp -o device.o
+In file included from device.cpp:2:
+torch_types.h:7: warning: "LANTERN_HOST_HANDLER" redefined
+    7 | #define LANTERN_HOST_HANDLER lantern_host_handler();
+      | 
+In file included from device.cpp:1:
+lantern/lantern.h:35: note: this is the location of the previous definition
+   35 | #define LANTERN_HOST_HANDLER
+      | 
+In file included from device.cpp:1:
+lantern/lantern.h: In function ‘bool lanternInit(const string&, std::string*)’:
+lantern/lantern.h:4097:6: note: variable tracking size limit exceeded with ‘-fvar-tracking-assignments’, retrying without
+ 4097 | bool lanternInit(const std::string &libPath, std::string *pError)
+      |      ^~~~~~~~~~~
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c dimname_list.cpp -o dimname_list.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c dtype.cpp -o dtype.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c gen-namespace.cpp -o gen-namespace.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c generator.cpp -o generator.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c indexing.cpp -o indexing.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c lantern.cpp -o lantern.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c layout.cpp -o layout.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c memory_format.cpp -o memory_format.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c nn_utils_rnn.cpp -o nn_utils_rnn.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c qscheme.cpp -o qscheme.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c quantization.cpp -o quantization.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c reduction.cpp -o reduction.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c save.cpp -o save.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c scalar.cpp -o scalar.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c storage.cpp -o storage.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c tensor.cpp -o tensor.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c tensor_list.cpp -o tensor_list.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c tensor_options.cpp -o tensor_options.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c utils.cpp -o utils.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c variable_list.cpp -o variable_list.o
+g++ -std=gnu++11 -shared -L/usr/lib/R/lib -Wl,-Bsymbolic-functions -Wl,-z,relro -o torch.so RcppExports.o autograd.o contrib.o cuda.o device.o dimname_list.o dtype.o gen-namespace.o generator.o indexing.o lantern.o layout.o memory_format.o nn_utils_rnn.o qscheme.o quantization.o reduction.o save.o scalar.o storage.o tensor.o tensor_list.o tensor_options.o utils.o variable_list.o -L/usr/lib/R/lib -lR
+Renaming torch lib to torchpkg
+"/usr/lib/R/bin/Rscript" "../tools/renamelib.R"
+installing to /tmp/workdir/torch/old/torch.Rcheck/00LOCK-torch/00new/torch/libs
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+** help
+*** installing help indices
+*** copying figures
+** building package indices
+** installing vignettes
+** testing if installed package can be loaded from temporary location
+** checking absolute paths in shared objects and dynamic libraries
+** testing if installed package can be loaded from final location
+** testing if installed package keeps a record of temporary installation path
+* DONE (torch)
+
+```

--- a/revdep/problems.md
+++ b/revdep/problems.md
@@ -41,120 +41,18 @@ Run `cloud_details(, "datamaps")` for more info
     Execution halted
     ```
 
-# detrendr
+# jqr
 
 <details>
 
-* Version: 0.6.8
-* Source code: https://github.com/cran/detrendr
-* URL: https://rorynolan.github.io/detrendr, https://www.github.com/rorynolan/detrendr#readme
-* BugReports: https://www.github.com/rorynolan/detrendr/issues
-* Date/Publication: 2020-08-03 15:30:18 UTC
-* Number of recursive dependencies: 102
+* Version: 1.1.0
+* Source code: https://github.com/cran/jqr
+* URL: https://github.com/ropensci/jqr
+* BugReports: https://github.com/ropensci/jqr/issues
+* Date/Publication: 2018-10-22 22:20:55 UTC
+* Number of recursive dependencies: 54
 
-Run `cloud_details(, "detrendr")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking tests ... ERROR
-    ```
-      Running ‘spelling.R’
-      Running ‘testthat.R’
-    Running the tests in ‘tests/testthat.R’ failed.
-    Last 13 lines of output:
-      > if (!detrendr:::win32bit()) test_check("detrendr")
-      ── 1. Error: best_swaps() works (@test-best_params.R#113)  ─────────────────────
-      Your image is too close to zero. Can't detrend an image with so few nonzero values. 
-      * `img` has 375000 elements and just 374998 of them are greater than zero.
-      Backtrace:
-       1. testthat::expect_equal(...)
-       4. detrendr::best_swaps(img, quick = TRUE)
-       8. detrendr:::best_swaps_naive(img)
-      
-      ══ testthat results  ═══════════════════════════════════════════════════════════
-      [ OK: 66 | SKIPPED: 19 | WARNINGS: 2 | FAILED: 1 ]
-      1. Error: best_swaps() works (@test-best_params.R#113) 
-      
-      Error: testthat unit tests failed
-      Execution halted
-    ```
-
-## In both
-
-*   checking installed package size ... NOTE
-    ```
-      installed size is  7.8Mb
-      sub-directories of 1Mb or more:
-        libs   6.6Mb
-    ```
-
-*   checking for GNU extensions in Makefiles ... NOTE
-    ```
-    GNU make is a SystemRequirements.
-    ```
-
-# dragon
-
-<details>
-
-* Version: 1.0.1
-* Source code: https://github.com/cran/dragon
-* URL: https://github.com/sjspielman/dragon
-* BugReports: https://github.com/sjspielman/dragon/issues
-* Date/Publication: 2020-07-19 00:10:03 UTC
-* Number of recursive dependencies: 124
-
-Run `cloud_details(, "dragon")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking tests ... ERROR
-    ```
-      Running ‘testthat.R’
-    Running the tests in ‘tests/testthat.R’ failed.
-    Last 13 lines of output:
-      Backtrace:
-      
-      ══ testthat results  ═══════════════════════════════════════════════════════════
-      [ OK: 105 | SKIPPED: 3 | WARNINGS: 0 | FAILED: 8 ]
-      1. Error: fct_build_network::initialize_data_age() using maximum known age (@test_build-network.R#76) 
-      2. Error: fct_build_network::initialize_data_age() using minimum known age (@test_build-network.R#103) 
-      3. Error: fct_build_network::construct_network() with elements_by_redox = F (@test_build-network.R#129) 
-      4. Error: fct_build_network::construct_network() with elements_by_redox = T (@test_build-network.R#167) 
-      5. Error: fct_build_network::specify_community_detect_network() with Louvain community clustering (@test_build-network.R#204) 
-      6. Error: fct_build_network::initialize_network() works (@test_build-network.R#226) 
-      7. Error: fct_export_network::* works  (@test_export-network.R#15) 
-      8. Error: fct_timeline::prepare_timeline_data() works (@test_timeline.R#14) 
-      
-      Error: testthat unit tests failed
-      Execution halted
-    ```
-
-## In both
-
-*   checking dependencies in R code ... NOTE
-    ```
-    Namespaces in Imports field not imported from:
-      ‘htmltools’ ‘magrittr’ ‘promises’
-      All declared Imports should be used.
-    ```
-
-# finalfit
-
-<details>
-
-* Version: 1.0.2
-* Source code: https://github.com/cran/finalfit
-* URL: https://github.com/ewenharrison/finalfit
-* BugReports: https://github.com/ewenharrison/finalfit/issues
-* Date/Publication: 2020-07-03 13:10:03 UTC
-* Number of recursive dependencies: 139
-
-Run `cloud_details(, "finalfit")` for more info
+Run `cloud_details(, "jqr")` for more info
 
 </details>
 
@@ -162,158 +60,40 @@ Run `cloud_details(, "finalfit")` for more info
 
 *   checking examples ... ERROR
     ```
-    ...
+    Running examples in ‘jqr-Ex.R’ failed
+    The error most likely occurred in:
+    
+    > ### Name: combine
+    > ### Title: Combine json pieces
+    > ### Aliases: combine
     > 
-    > colon_s %>%
-    + 	glmuni(dependent, explanatory) %>%
-    + 	fit2df(estimate_suffix=" (univariable)") -> example.univariable
-    Waiting for profiling to be done...
-    Waiting for profiling to be done...
-    Waiting for profiling to be done...
-    Waiting for profiling to be done...
+    > ### ** Examples
     > 
-    > colon_s %>%
-    + 	 glmmulti(dependent, explanatory) %>%
-    + 	 fit2df(estimate_suffix=" (multivariable)") -> example.multivariable
-    Waiting for profiling to be done...
-    > 
-    > colon_s %>%
-    +   glmmixed(dependent, explanatory, random_effect) %>%
-    + 	 fit2df(estimate_suffix=" (multilevel") -> example.multilevel
-    Error in exists(v, envir = env, inherits = FALSE) : 
-      use of NULL environment is defunct
-    Calls: %>% ... checkFormulaData -> allvarex -> vapply -> FUN -> exists
+    > x <- '{"foo": 5, "bar": 7}' %>% select(a = .foo)
+    > combine(x)
+    Error: Must be class jqson
     Execution halted
     ```
 
-# nandb
-
-<details>
-
-* Version: 2.0.7
-* Source code: https://github.com/cran/nandb
-* URL: https://rorynolan.github.io/nandb, https://github.com/rorynolan/nandb
-* BugReports: https://github.com/rorynolan/nandb/issues
-* Date/Publication: 2020-05-08 13:10:06 UTC
-* Number of recursive dependencies: 106
-
-Run `cloud_details(, "nandb")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking tests ... ERROR
-    ```
-      Running ‘spelling.R’
-      Running ‘testthat.R’
-    Running the tests in ‘tests/testthat.R’ failed.
-    Last 13 lines of output:
-       13. detrendr:::best_swaps_naive(img)
-      
-      ══ testthat results  ═══════════════════════════════════════════════════════════
-      [ OK: 101 | SKIPPED: 0 | WARNINGS: 0 | FAILED: 8 ]
-      1. Error: brightness works (@test-brightness.R#5) 
-      2. Error: brightness_timeseries works (@test-brightness.R#128) 
-      3. Error: cc_brightness() works (@test-cc_brightness.R#7) 
-      4. Error: cc_brightness_timeseries() works (@test-cc_brightness.R#65) 
-      5. Error: cc_number() works (@test-cc_number.R#7) 
-      6. Error: cc_number_timeseries() works (@test-cc_number.R#65) 
-      7. Error: number works (@test-number.R#5) 
-      8. Error: number_timeseries works (@test-number.R#200) 
-      
-      Error: testthat unit tests failed
-      Execution halted
-    ```
-
-# nlmixr
-
-<details>
-
-* Version: 1.1.1-9
-* Source code: https://github.com/cran/nlmixr
-* URL: https://github.com/nlmixrdevelopment/nlmixr
-* Date/Publication: 2020-06-22 08:50:08 UTC
-* Number of recursive dependencies: 154
-
-Run `cloud_details(, "nlmixr")` for more info
-
-</details>
-
-## Newly broken
-
 *   checking tests ... ERROR
     ```
       Running ‘testthat.R’
     Running the tests in ‘tests/testthat.R’ failed.
     Last 13 lines of output:
-      > library(nlmixr)
-      > 
-      > test_check("nlmixr")
-      ── 1. Error: UI updates work correctly (@test-piping.R#63)  ────────────────────
-      object '.tmp' not found
-      Backtrace:
-       1. f %>% update(tka = 4, cl = exp(tcl), ka = exp(tka), .tmp)
-       3. nlmixr:::update.nlmixrUI(...)
+      ● empty test (1)
       
       ══ testthat results  ═══════════════════════════════════════════════════════════
-      [ OK: 188 | SKIPPED: 0 | WARNINGS: 0 | FAILED: 1 ]
-      1. Error: UI updates work correctly (@test-piping.R#63) 
+      FAILURE (test-dsl.R:132:3): maths
+      FAILURE (test-dsl.R:177:3): construct objects
+      FAILURE (test-dsl.R:178:3): construct objects
+      FAILURE (test-dsl.R:187:3): paths
+      FAILURE (test-dsl.R:190:3): paths
+      FAILURE (test-dsl.R:192:3): paths
+      FAILURE (test-dsl.R:202:3): recurse
+      FAILURE (test-dsl.R:206:3): recurse
       
-      Error: testthat unit tests failed
-      Execution halted
-    ```
-
-## In both
-
-*   checking installed package size ... NOTE
-    ```
-      installed size is 28.6Mb
-      sub-directories of 1Mb or more:
-        libs  26.9Mb
-    ```
-
-*   checking dependencies in R code ... NOTE
-    ```
-    Namespace in Imports field not imported from: ‘stringr’
-      All declared Imports should be used.
-    ```
-
-# r2dii.analysis
-
-<details>
-
-* Version: 0.0.1
-* Source code: https://github.com/cran/r2dii.analysis
-* URL: https://github.com/2DegreesInvesting/r2dii.analysis
-* BugReports: https://github.com/2DegreesInvesting/r2dii.analysis/issues
-* Date/Publication: 2020-06-28 10:20:03 UTC
-* Number of recursive dependencies: 64
-
-Run `cloud_details(, "r2dii.analysis")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking tests ... ERROR
-    ```
-      Running ‘spelling.R’
-      Running ‘testthat.R’
-    Running the tests in ‘tests/testthat.R’ failed.
-    Complete output:
-      > library(testthat)
-      > library(r2dii.analysis)
-      > 
-      > test_check("r2dii.analysis")
-      ── 1. Failure: returns visibly (@test-join_ald_scenario.R#17)  ─────────────────
-      join_ald_scenario(...) does not invisibly
-      
-      ══ testthat results  ═══════════════════════════════════════════════════════════
-      [ OK: 104 | SKIPPED: 0 | WARNINGS: 0 | FAILED: 1 ]
-      1. Failure: returns visibly (@test-join_ald_scenario.R#17) 
-      
-      Error: testthat unit tests failed
+      [ FAIL 8 | WARN 0 | SKIP 1 | PASS 114 ]
+      Error: Test failures
       Execution halted
     ```
 
@@ -351,58 +131,18 @@ Run `cloud_details(, "rcrtan")` for more info
     Execution halted
     ```
 
-# rlang
+# reproducible
 
 <details>
 
-* Version: 0.4.7
-* Source code: https://github.com/cran/rlang
-* URL: http://rlang.r-lib.org, https://github.com/r-lib/rlang
-* BugReports: https://github.com/r-lib/rlang/issues
-* Date/Publication: 2020-07-09 23:00:18 UTC
-* Number of recursive dependencies: 48
+* Version: 1.2.1
+* Source code: https://github.com/cran/reproducible
+* URL: https://reproducible.predictiveecology.org, https://github.com/PredictiveEcology/reproducible
+* BugReports: https://github.com/PredictiveEcology/reproducible/issues
+* Date/Publication: 2020-08-18 07:20:36 UTC
+* Number of recursive dependencies: 106
 
-Run `cloud_details(, "rlang")` for more info
-
-</details>
-
-## Newly broken
-
-*   checking tests ... ERROR
-    ```
-      Running ‘sink.R’
-      Running ‘testthat.R’
-    Running the tests in ‘tests/testthat.R’ failed.
-    Last 13 lines of output:
-      ══ testthat results  ═══════════════════════════════════════════════════════════
-      [ OK: 2686 | SKIPPED: 25 | WARNINGS: 2 | FAILED: 14 ]
-      1. Failure: %>% frames are collapsed (@test-trace.R#219) 
-      2. Failure: %>% frames are collapsed (@test-trace.R#222) 
-      3. Failure: %>% frames are collapsed (@test-trace.R#225) 
-      4. Failure: children of collapsed %>% frames have correct parent (@test-trace.R#245) 
-      5. Failure: combinations of incomplete and leading pipes collapse properly (@test-trace.R#303) 
-      6. Failure: combinations of incomplete and leading pipes collapse properly (@test-trace.R#306) 
-      7. Failure: combinations of incomplete and leading pipes collapse properly (@test-trace.R#309) 
-      8. Failure: combinations of incomplete and leading pipes collapse properly (@test-trace.R#312) 
-      9. Failure: combinations of incomplete and leading pipes collapse properly (@test-trace.R#315) 
-      1. ...
-      
-      Error: testthat unit tests failed
-      Execution halted
-    ```
-
-# taber
-
-<details>
-
-* Version: 0.1.0
-* Source code: https://github.com/cran/taber
-* URL: http://github.com/restonslacker/taber
-* BugReports: http://github.com/restonslacker/taber/issues
-* Date/Publication: 2015-08-03 21:10:50
-* Number of recursive dependencies: 20
-
-Run `cloud_details(, "taber")` for more info
+Run `cloud_details(, "reproducible")` for more info
 
 </details>
 
@@ -411,27 +151,158 @@ Run `cloud_details(, "taber")` for more info
 *   checking examples ... ERROR
     ```
     ...
+    > ### Name: Cache
+    > ### Title: Cache method that accommodates environments, S4 methods,
+    > ###   Rasters, & nested caching
+    > ### Aliases: Cache Cache,ANY-method
+    > 
     > ### ** Examples
     > 
-    > library(dplyr)
-    
-    Attaching package: ‘dplyr’
-    
-    The following objects are masked from ‘package:stats’:
-    
-        filter, lag
-    
-    The following objects are masked from ‘package:base’:
-    
-        intersect, setdiff, setequal, union
-    
-    > aframe <- data.frame(zed = runif(100))
-    > set_to_zero <- . %>% mutate(zed = 0)
-    > aframe %>% scion(zed >0.5, false_fun=set_to_zero) %>% mutate(zed=1) %>% graft
-    Error in .pop() : 
-      No more scions on stack. Perhaps you meant to specify the "data2" argument to graft()?
-    Calls: %>% -> graft -> .pop
+    > tmpDir <- file.path(tempdir())
+    > 
+    > # Basic use
+    > ranNumsA <- Cache(rnorm, 10, 16, cacheRepo = tmpDir)
+    > 
+    > # All same
+    > ranNumsB <- Cache(rnorm, 10, 16, cacheRepo = tmpDir) # recovers cached copy
+      ...(Object to retrieve (f11fb1a2880f8060.rds))
+         loaded cached result from previous rnorm call, 
+    > ranNumsC <- Cache(cacheRepo = tmpDir) %C% rnorm(10, 16)  # recovers cached copy
+    Error in get(x, envir = ns, inherits = FALSE) : 
+      object 'split_chain' not found
+    Calls: %C% -> getFromNamespace -> get
     Execution halted
+    ```
+
+*   checking tests ... ERROR
+    ```
+      Running ‘test-all.R’
+    Running the tests in ‘tests/test-all.R’ failed.
+    Last 13 lines of output:
+      ── Skipped tests  ──────────────────────────────────────────────────────────────
+      ● No Drive token is not TRUE (5)
+      ● On CRAN (58)
+      ● empty test (6)
+      ● test cloudCache inside Cache -- Not fully written test (1)
+      
+      ══ testthat results  ═══════════════════════════════════════════════════════════
+      ERROR (test-cache.R:550:3): test pipe for Cache
+      Warning (test-copy.R:8:3): test Copy
+      Warning (test-prepInputs.R:1803:3): rasters aren't properly resampled
+      Warning (test-prepInputs.R:1818:3): rasters aren't properly resampled
+      
+      [ FAIL 1 | WARN 3 | SKIP 70 | PASS 354 ]
+      Error: Test failures
+      Execution halted
+    ```
+
+# ripe
+
+<details>
+
+* Version: 0.1.0
+* Source code: https://github.com/cran/ripe
+* URL: https://github.com/yonicd/ripe
+* BugReports: https://github.com/yonicd/ripe/issues
+* Date/Publication: 2019-12-06 10:10:02 UTC
+* Number of recursive dependencies: 59
+
+Run `cloud_details(, "ripe")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking whether package ‘ripe’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/tmp/workdir/ripe/new/ripe.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘ripe’ ...
+** package ‘ripe’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+Error in get("is_pipe", asNamespace("magrittr")) : 
+  object 'is_pipe' not found
+Error: unable to load R code in package ‘ripe’
+Execution halted
+ERROR: lazy loading failed for package ‘ripe’
+* removing ‘/tmp/workdir/ripe/new/ripe.Rcheck/ripe’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘ripe’ ...
+** package ‘ripe’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+** help
+*** installing help indices
+** building package indices
+** installing vignettes
+** testing if installed package can be loaded from temporary location
+** testing if installed package can be loaded from final location
+** testing if installed package keeps a record of temporary installation path
+* DONE (ripe)
+
+```
+# sketch
+
+<details>
+
+* Version: 1.0.3
+* Source code: https://github.com/cran/sketch
+* BugReports: https://github.com/kcf-jackson/sketch
+* Date/Publication: 2020-10-08 07:40:03 UTC
+* Number of recursive dependencies: 66
+
+Run `cloud_details(, "sketch")` for more info
+
+</details>
+
+## Newly broken
+
+*   checking examples ... ERROR
+    ```
+    Running examples in ‘sketch-Ex.R’ failed
+    The error most likely occurred in:
+    
+    > ### Name: compile_r
+    > ### Title: Compile an R file into a JavaScript file
+    > ### Aliases: compile_r
+    > 
+    > ### ** Examples
+    > 
+    > file <- system.file("test_files/test_source.R", package = "sketch")
+    > readLines(file)
+    [1] "console::log(\"'test_source.R' runs successfully.\")"
+    > compile_r(input = file)
+    Error: C stack usage  7969652 is too close to the limit
+    Execution halted
+    ```
+
+*   checking tests ... ERROR
+    ```
+      Running ‘testthat.R’
+    Running the tests in ‘tests/testthat.R’ failed.
+    Complete output:
+      > library(testthat)
+      > library(sketch)
+      > 
+      > test_check("sketch")
+      Error: C stack usage  7970324 is too close to the limit
+      Execution halted
     ```
 
 # tidytidbits
@@ -475,68 +346,161 @@ Run `cloud_details(, "tidytidbits")` for more info
     Execution halted
     ```
 
-# xpose
+# torch
 
 <details>
 
-* Version: 0.4.11
-* Source code: https://github.com/cran/xpose
-* URL: https://github.com/UUPharmacometrics/xpose
-* BugReports: https://github.com/UUPharmacometrics/xpose/issues
-* Date/Publication: 2020-07-22 21:10:03 UTC
-* Number of recursive dependencies: 96
+* Version: 0.1.1
+* Source code: https://github.com/cran/torch
+* URL: https://torch.mlverse.org/docs, https://github.com/mlverse/torch
+* BugReports: https://github.com/mlverse/torch/issues
+* Date/Publication: 2020-10-20 21:10:02 UTC
+* Number of recursive dependencies: 59
 
-Run `cloud_details(, "xpose")` for more info
+Run `cloud_details(, "torch")` for more info
 
 </details>
 
 ## Newly broken
 
-*   checking examples ... ERROR
+*   checking whether package ‘torch’ can be installed ... ERROR
     ```
-    ...
-    > 
-    > # List output files data
-    > list_files(xpdb_ex_pk)
-    Files:
-      name       extension problem subprob method data               modified
-      <chr>      <chr>       <dbl>   <dbl> <chr>  <list>             <lgl>   
-    1 run001.cor cor             1       0 foce   <tibble [14 × 15]> FALSE   
-    2 run001.cov cov             1       0 foce   <tibble [14 × 15]> FALSE   
-    3 run001.ext ext             1       0 foce   <tibble [28 × 16]> FALSE   
-    4 run001.grd grd             1       0 foce   <tibble [21 × 11]> FALSE   
-    5 run001.phi phi             1       0 foce   <tibble [74 × 12]> FALSE   
-    6 run001.shk shk             1       0 foce   <tibble [7 × 5]>   FALSE   
-    > 
-    > # List special data
-    > xpdb_ex_pk %>% 
-    + vpc_data(quiet = TRUE) %>% 
-    + list_special()
-    Error in split_chain(match.call(), env = env) : 
-      could not find function "split_chain"
-    Calls: %>% ... <Anonymous> -> vpc.default -> do.call -> <Anonymous> -> %>%
-    Execution halted
+    Installation failed.
+    See ‘/tmp/workdir/torch/new/torch.Rcheck/00install.out’ for details.
     ```
 
-*   checking tests ... ERROR
+## Newly fixed
+
+*   checking installed package size ... NOTE
     ```
-      Running ‘testthat.R’
-    Running the tests in ‘tests/testthat.R’ failed.
-    Last 13 lines of output:
-      Backtrace:
-        1. `%>%`(...)
-        5. xpose::vpc_data(., quiet = TRUE)
-       10. `%>%`(...)
-      
-      ══ testthat results  ═══════════════════════════════════════════════════════════
-      [ OK: 460 | SKIPPED: 6 | WARNINGS: 0 | FAILED: 5 ]
-      1. Error: (unknown) (@test-console_outputs.R#4) 
-      2. Error: (unknown) (@test-edits.R#18) 
-      3. Error: (unknown) (@test-vpc.R#17) 
-      4. Error: get_special checks input properly (@test-xpdb_access.R#193) 
-      5. Error: get_data works properly (@test-xpdb_access.R#209) 
-      
-      Error: testthat unit tests failed
-      Execution halted
+      installed size is 157.6Mb
+      sub-directories of 1Mb or more:
+        R       3.1Mb
+        help    2.8Mb
+        libs  151.2Mb
     ```
 
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘torch’ ...
+** package ‘torch’ successfully unpacked and MD5 sums checked
+** using staged installation
+** libs
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c RcppExports.cpp -o RcppExports.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c autograd.cpp -o autograd.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c contrib.cpp -o contrib.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c cuda.cpp -o cuda.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c device.cpp -o device.o
+In file included from device.cpp:2:
+torch_types.h:7: warning: "LANTERN_HOST_HANDLER" redefined
+    7 | #define LANTERN_HOST_HANDLER lantern_host_handler();
+      | 
+In file included from device.cpp:1:
+lantern/lantern.h:35: note: this is the location of the previous definition
+   35 | #define LANTERN_HOST_HANDLER
+      | 
+In file included from device.cpp:1:
+lantern/lantern.h: In function ‘bool lanternInit(const string&, std::string*)’:
+lantern/lantern.h:4097:6: note: variable tracking size limit exceeded with ‘-fvar-tracking-assignments’, retrying without
+ 4097 | bool lanternInit(const std::string &libPath, std::string *pError)
+      |      ^~~~~~~~~~~
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c dimname_list.cpp -o dimname_list.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c dtype.cpp -o dtype.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c gen-namespace.cpp -o gen-namespace.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c generator.cpp -o generator.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c indexing.cpp -o indexing.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c lantern.cpp -o lantern.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c layout.cpp -o layout.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c memory_format.cpp -o memory_format.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c nn_utils_rnn.cpp -o nn_utils_rnn.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c qscheme.cpp -o qscheme.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c quantization.cpp -o quantization.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c reduction.cpp -o reduction.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c save.cpp -o save.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c scalar.cpp -o scalar.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c storage.cpp -o storage.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c tensor.cpp -o tensor.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c tensor_list.cpp -o tensor_list.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c tensor_options.cpp -o tensor_options.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c utils.cpp -o utils.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c variable_list.cpp -o variable_list.o
+g++ -std=gnu++11 -shared -L/usr/lib/R/lib -Wl,-Bsymbolic-functions -Wl,-z,relro -o torch.so RcppExports.o autograd.o contrib.o cuda.o device.o dimname_list.o dtype.o gen-namespace.o generator.o indexing.o lantern.o layout.o memory_format.o nn_utils_rnn.o qscheme.o quantization.o reduction.o save.o scalar.o storage.o tensor.o tensor_list.o tensor_options.o utils.o variable_list.o -L/usr/lib/R/lib -lR
+Renaming torch lib to torchpkg
+"/usr/lib/R/bin/Rscript" "../tools/renamelib.R"
+installing to /tmp/workdir/torch/new/torch.Rcheck/00LOCK-torch/00new/torch/libs
+** R
+Warning in dir.create(outCodeDir) :
+  cannot create dir '/tmp/workdir/torch/new/torch.Rcheck/00LOCK-torch/00new/torch/R', reason 'No space left on device'
+Error in .install_package_code_files(".", instdir) : 
+  cannot open directory '/tmp/workdir/torch/new/torch.Rcheck/00LOCK-torch/00new/torch/R'
+ERROR: unable to collate and parse R files for package ‘torch’
+* removing ‘/tmp/workdir/torch/new/torch.Rcheck/torch’
+
+```
+### CRAN
+
+```
+* installing *source* package ‘torch’ ...
+** package ‘torch’ successfully unpacked and MD5 sums checked
+** using staged installation
+** libs
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c RcppExports.cpp -o RcppExports.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c autograd.cpp -o autograd.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c contrib.cpp -o contrib.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c cuda.cpp -o cuda.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c device.cpp -o device.o
+In file included from device.cpp:2:
+torch_types.h:7: warning: "LANTERN_HOST_HANDLER" redefined
+    7 | #define LANTERN_HOST_HANDLER lantern_host_handler();
+      | 
+In file included from device.cpp:1:
+lantern/lantern.h:35: note: this is the location of the previous definition
+   35 | #define LANTERN_HOST_HANDLER
+      | 
+In file included from device.cpp:1:
+lantern/lantern.h: In function ‘bool lanternInit(const string&, std::string*)’:
+lantern/lantern.h:4097:6: note: variable tracking size limit exceeded with ‘-fvar-tracking-assignments’, retrying without
+ 4097 | bool lanternInit(const std::string &libPath, std::string *pError)
+      |      ^~~~~~~~~~~
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c dimname_list.cpp -o dimname_list.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c dtype.cpp -o dtype.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c gen-namespace.cpp -o gen-namespace.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c generator.cpp -o generator.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c indexing.cpp -o indexing.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c lantern.cpp -o lantern.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c layout.cpp -o layout.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c memory_format.cpp -o memory_format.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c nn_utils_rnn.cpp -o nn_utils_rnn.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c qscheme.cpp -o qscheme.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c quantization.cpp -o quantization.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c reduction.cpp -o reduction.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c save.cpp -o save.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c scalar.cpp -o scalar.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c storage.cpp -o storage.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c tensor.cpp -o tensor.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c tensor_list.cpp -o tensor_list.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c tensor_options.cpp -o tensor_options.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c utils.cpp -o utils.o
+g++ -std=gnu++11 -I"/usr/share/R/include" -DNDEBUG  -I"/usr/local/lib/R/site-library/Rcpp/include"   -fpic  -g -O2 -fdebug-prefix-map=/build/r-base-jbaK_j/r-base-3.6.3=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -g  -c variable_list.cpp -o variable_list.o
+g++ -std=gnu++11 -shared -L/usr/lib/R/lib -Wl,-Bsymbolic-functions -Wl,-z,relro -o torch.so RcppExports.o autograd.o contrib.o cuda.o device.o dimname_list.o dtype.o gen-namespace.o generator.o indexing.o lantern.o layout.o memory_format.o nn_utils_rnn.o qscheme.o quantization.o reduction.o save.o scalar.o storage.o tensor.o tensor_list.o tensor_options.o utils.o variable_list.o -L/usr/lib/R/lib -lR
+Renaming torch lib to torchpkg
+"/usr/lib/R/bin/Rscript" "../tools/renamelib.R"
+installing to /tmp/workdir/torch/old/torch.Rcheck/00LOCK-torch/00new/torch/libs
+** R
+** inst
+** byte-compile and prepare package for lazy loading
+** help
+*** installing help indices
+*** copying figures
+** building package indices
+** installing vignettes
+** testing if installed package can be loaded from temporary location
+** checking absolute paths in shared objects and dynamic libraries
+** testing if installed package can be loaded from final location
+** testing if installed package keeps a record of temporary installation path
+* DONE (torch)
+
+```

--- a/vignettes/magrittr.Rmd
+++ b/vignettes/magrittr.Rmd
@@ -207,4 +207,4 @@ To see a list of the aliases, execute e.g. `?multiply_by`.
 # Development
 The *magrittr* package is also available in a development version at the
 GitHub development page:
-[github.com/tidyverse/magrittr](http://github.com/tidyverse/magrittr).
+[github.com/tidyverse/magrittr](https://github.com/tidyverse/magrittr).


### PR DESCRIPTION
Includes #230.

I ran revdep checks again (for magrittr, dplyr, tidyr, and purrr, about 3000 packages) and found 6 remaining failing packages. Three of them were already found in a previous run and the authors were notified or provided a fix at that time (about two months ago):

- datamaps (fix at https://github.com/JohnCoene/datamaps/issues/2)
- rcrtan (fix at https://github.com/gtlaflair/rcrtan/pull/5)
- tidytidbits (notified by email)

Three failures are new:

- jqr (fix at https://github.com/ropensci/jqr/pull/82)
- reproducible (issue at https://github.com/PredictiveEcology/reproducible/issues/169)
- sketch, which I can't reproduce locally

I ran checks on win-builder, r-hub (including sanitizers and rchk) and found no issues.