### PR TITLE
validate lhs is a LANGSXP before CDR usage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # magrittr (development version)
 
+* Fixed an issue that could cause pipe invocations to fail in versions of
+  R built with `--enable-strict-barrier`. (#239, @kevinushey)
 
 # magrittr 2.0.1
 

--- a/src/pipe.c
+++ b/src/pipe.c
@@ -244,7 +244,9 @@ SEXP pipe_unroll(SEXP lhs,
     out = Rf_cons(rhs, out);
     REPROTECT(out, out_pi);
 
-    SEXP args = CDR(lhs);
+    SEXP args = R_NilValue;
+    if (TYPEOF(lhs) == LANGSXP)
+      args = CDR(lhs);
 
     if ((kind = parse_pipe_call(lhs, pipe_sym))) {
       lhs = CAR(args);

--- a/src/pipe.c
+++ b/src/pipe.c
@@ -244,11 +244,11 @@ SEXP pipe_unroll(SEXP lhs,
     out = Rf_cons(rhs, out);
     REPROTECT(out, out_pi);
 
-    SEXP args = R_NilValue;
-    if (TYPEOF(lhs) == LANGSXP)
-      args = CDR(lhs);
-
     if ((kind = parse_pipe_call(lhs, pipe_sym))) {
+      if (TYPEOF(lhs) != LANGSXP) {
+        Rf_error("Internal error in `pipe_unroll()`: Expected LHS call.");
+      }
+      SEXP args = CDR(lhs);
       lhs = CAR(args);
       rhs = CADR(args);
       continue;


### PR DESCRIPTION
Closes #239. I _think_ the code here intends to handle call objects that might be on the LHS of the pipe; e.g. usages like:

```
rnorm(1) %>% identity()
```

and if that's indeed the case, then I think the type of `lhs` needs to be checked before accessing via `CDR()`.