### PR TITLE
rm tab character from debug_pipe.R

### DIFF
--- a/R/debug_pipe.R
+++ b/R/debug_pipe.R
@@ -43,4 +43,3 @@ undebug_fseq <- function(fseq)
     if (isdebugged(functions(fseq)[[i]])) 
       undebug(functions(fseq)[[i]])
 }
-	


### PR DESCRIPTION
There was a presumably accidental tab character there. Why does it matter? I'm about to apply a [`pkgstats` package](https://github.com/mpadge/pkgstats) to the entire historical CRAN archive, for which `magrittr` is used as a conveniently small demo package. The analyses are largely derived from outputs of both [`ctags`](https://ctags.io) and [`gtags`](https://www.gnu.org/software/global/), but tab characters mess with these outputs, and can lead to errors when attempting to automatically analyse code.