### PR TITLE
Make testthat tests conditional on its presence.

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -2,4 +2,5 @@ if (require(testthat)) {
   library(magrittr)
 
   test_check("magrittr")
-}
+} else
+  warning("'magrittr' requires 'testthat' for tests")

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,5 @@
-library(testthat)
-library(magrittr)
+if (require(testthat)) {
+  library(magrittr)
 
-test_check("magrittr")
+  test_check("magrittr")
+}


### PR DESCRIPTION
`magrittr` fails tests on CRAN in winUCRT because `testthat` is missing.
`testthat` is a suggested package.

This creates a huge cascade of failures of packages that depend on `magrittr`.

`magrittr` should be able to pass tests on CRAN with no ERRORs even
if suggested packages are missing.

This PR reduces the `magrittr` problems to a NOTE about `testthat`
being missing.