### PR TITLE
Ensure that `prev_mask` is always protected

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # magrittr (development version)
 
+* Fixed a rare C level protection issue in `%>%` (#256).
+
 # magrittr 2.0.2
 
 * New eager pipe `%!>%` for sequential evaluation (#247). Consider

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # magrittr (development version)
 
-* Fixed a rare C level protection issue in `%>%` (#256).
+* Fixed a C level protection issue in `%>%` (#256).
 
 # magrittr 2.0.2
 

--- a/src/pipe.c
+++ b/src/pipe.c
@@ -153,6 +153,8 @@ SEXP eval_pipe(void* data) {
 static
 SEXP eval_pipe_lazy(SEXP exprs, SEXP env) {
   SEXP prev_mask = env;
+  PROTECT_INDEX prev_mask_pi;
+  PROTECT_WITH_INDEX(prev_mask, &prev_mask_pi);
 
   PROTECT_INDEX mask_pi;
   PROTECT_WITH_INDEX(R_NilValue, &mask_pi);
@@ -169,6 +171,7 @@ SEXP eval_pipe_lazy(SEXP exprs, SEXP env) {
 
     exprs = rest;
     prev_mask = mask;
+    REPROTECT(prev_mask, prev_mask_pi);
   }
 
   // For compatibility, allow last expression to be `return()`.
@@ -182,7 +185,7 @@ SEXP eval_pipe_lazy(SEXP exprs, SEXP env) {
   // recursive evaluation of `.` bindings in the different masks.
   SEXP out = Rf_eval(last, prev_mask);
 
-  UNPROTECT(1);
+  UNPROTECT(2);
   return out;
 }
 


### PR DESCRIPTION
Closes https://github.com/tidyverse/dplyr/issues/6207

The most minimal reprex I could come up with to show this issue was:

```r
library(magrittr)

var <- "x"
data <- data.frame(feature = letters[1:10], imp = 1:10)

gctorture2(5L)

for (kk in 1:100) {
  cat(sprintf("Run #%d\n", kk))
  
  data.frame(feature = letters[1:10]) %>%
    dplyr::left_join(data, by = "feature") %>%
    dplyr::mutate(!!var := 1.0)
}

cat("Done\n")
```

Which would often error with:

```r
Error in dplyr::mutate(., `:=`(!!var, 1)) : 
   'rho' must be an environment not promise: detected in C-level eval
```

This only happened when there were >=2 pipes in a pipe chain, and didn't happen at all when the pipes were removed. We also had to be very aggressive with `gctorture2()` to get it to show up at all, so it was probably very rare.

It turns out that as we are updating `prev_mask` and moving from one iteration of the `while` loop to the next, there is a very short window where `prev_mask` is unprotected and can be gc'd. On the second iteration of the `while` loop, right after `REPROTECT(mask, mask_pi);` the `prev_mask` becomes unprotected. The first line of `r_env_bind_lazy()` runs an allocating function, which is when it is possible for `prev_mask` to become gc'd. You can force this to happen reliably by placing `R_gc();` right after the `REPROTECT(mask, mask_pi);` line and running the reprex above.